### PR TITLE
allow multiple values per parameter

### DIFF
--- a/examples/test_client/test_oauth_client.py
+++ b/examples/test_client/test_oauth_client.py
@@ -42,9 +42,7 @@ class TestOAuthClient(object):
         full_url = self.server_url + relative_url
         url = urlparse.urlparse(full_url)
         query_params = cgi.parse_qs(url.query)
-        for key in query_params:
-            query_params[key] = query_params[key][0]
-
+        
         oauth_request = OAuthRequest.from_consumer_and_token(
                 self.consumer,
                 token = access_token,

--- a/third_party/oauth.py
+++ b/third_party/oauth.py
@@ -214,8 +214,14 @@ class OAuthRequest(object):
 
     def to_postdata(self):
         """Serialize as post data for a POST request."""
-        return '&'.join(['%s=%s' % (escape(str(k)), escape(str(v))) \
-            for k, v in self.parameters.iteritems()])
+        l = []
+        for k,v in self.parameters.iteritems():
+            if isinstance(v,list):
+                for i in v:
+                    l.append(escape(str(k))+'='+escape(str(i)))
+            else:
+                l.append(escape(str(k))+'='+escape(str(v)))
+        return '&'.join(l)
 
     def to_url(self):
         """Serialize as a URL for a GET request."""
@@ -230,12 +236,15 @@ class OAuthRequest(object):
         except:
             pass
         # Escape key values before sorting.
-        key_values = [(escape(_utf8_str(k)), escape(_utf8_str(v))) \
-            for k,v in params.items()]
-        # Sort lexicographically, first after key, then after value.
+        key_values = []
+        for k,v in params.items():
+            if isinstance(v,list):
+                key_values.append(escape(_utf8_str(k))+'='+escape(_utf8_str(v[0])))
+            else:
+                key_values.append(escape(_utf8_str(k))+'='+escape(_utf8_str(v)))
         key_values.sort()
         # Combine key value pairs into a string.
-        return '&'.join(['%s=%s' % (k, v) for k, v in key_values])
+        return '&'.join(key_values)
 
     def get_normalized_http_method(self):
         """Uppercases the http method."""


### PR DESCRIPTION
The original oauth client would only accept one value per parameter. By modifying the way the urls are formed, multiple values can be passed per parameter. This is helpful if one wants to look at 

/api/v1/user/exercises?email=example@email.org&exercises=addition_1&exercises=multiplication_1&exercises...

Previously, this would only return data for addition_1. Now it returns data for all exercises listed.